### PR TITLE
Use document instead of schema

### DIFF
--- a/lib/graphql/autotest.rb
+++ b/lib/graphql/autotest.rb
@@ -1,6 +1,7 @@
 require 'graphql'
 
 require_relative "autotest/version"
+require_relative "autotest/util"
 require_relative 'autotest/field'
 require_relative 'autotest/arguments_fetcher'
 require_relative 'autotest/report'

--- a/lib/graphql/autotest/arguments_fetcher.rb
+++ b/lib/graphql/autotest/arguments_fetcher.rb
@@ -10,8 +10,13 @@ module GraphQL
         end
       end
 
+      # @param arg [GraphQL::Language::Nodes::InputValueDefinition]
+      def self.non_null?(arg)
+        arg.type.is_a?(GraphQL::Language::Nodes::NonNullType)
+      end
+
       EMPTY = -> (field, ancestors:) { field.arguments.empty? && {} }
-      NO_REQUIRED = -> (field, ancestors:) { field.arguments.none? { |_k, v| v.type.non_null? } && {} }
+      NO_REQUIRED = -> (field, ancestors:) { field.arguments.none? { |arg| non_null?(arg) } && {} }
       DEFAULT = combine(EMPTY, NO_REQUIRED)
     end
   end

--- a/lib/graphql/autotest/arguments_fetcher.rb
+++ b/lib/graphql/autotest/arguments_fetcher.rb
@@ -10,13 +10,8 @@ module GraphQL
         end
       end
 
-      # @param arg [GraphQL::Language::Nodes::InputValueDefinition]
-      def self.non_null?(arg)
-        arg.type.is_a?(GraphQL::Language::Nodes::NonNullType)
-      end
-
       EMPTY = -> (field, ancestors:) { field.arguments.empty? && {} }
-      NO_REQUIRED = -> (field, ancestors:) { field.arguments.none? { |arg| non_null?(arg) } && {} }
+      NO_REQUIRED = -> (field, ancestors:) { field.arguments.none? { |arg| Util.non_null?(arg.type) } && {} }
       DEFAULT = combine(EMPTY, NO_REQUIRED)
     end
   end

--- a/lib/graphql/autotest/query_generator.rb
+++ b/lib/graphql/autotest/query_generator.rb
@@ -1,16 +1,16 @@
 module GraphQL
   module Autotest
     class QueryGenerator
-      attr_reader :schema, :arguments_fetcher, :max_depth, :skip_if
-      private :schema, :arguments_fetcher, :max_depth, :skip_if
+      attr_reader :document, :arguments_fetcher, :max_depth, :skip_if
+      private :document, :arguments_fetcher, :max_depth, :skip_if
 
       # See Runner#initialize for arguments documentation.
-      def self.generate(schema:, arguments_fetcher: ArgumentsFetcher::DEFAULT, max_depth: Float::INFINITY, skip_if: -> (_field, **) { false })
-        self.new(schema: schema, arguments_fetcher: arguments_fetcher, max_depth: max_depth, skip_if: skip_if).generate
+      def self.generate(document:, arguments_fetcher: ArgumentsFetcher::DEFAULT, max_depth: Float::INFINITY, skip_if: -> (_field, **) { false })
+        self.new(document: document, arguments_fetcher: arguments_fetcher, max_depth: max_depth, skip_if: skip_if).generate
       end
 
-      def initialize(schema:, arguments_fetcher:, max_depth: , skip_if:)
-        @schema = schema
+      def initialize(document:, arguments_fetcher:, max_depth: , skip_if:)
+        @document = document
         @arguments_fetcher = arguments_fetcher
         @max_depth = max_depth
         @skip_if = skip_if
@@ -61,7 +61,7 @@ module GraphQL
       end
 
       private def type_definition(name)
-        schema.definitions.find { |f| f.name == name }
+        document.definitions.find { |f| f.name == name }
       end
 
       private def unwrap(type)

--- a/lib/graphql/autotest/query_generator.rb
+++ b/lib/graphql/autotest/query_generator.rb
@@ -44,8 +44,9 @@ module GraphQL
             Field.new(name: f.name, children: nil, arguments: arguments)
           when GraphQL::Language::Nodes::UnionTypeDefinition
             possible_types = field_type_def.types.map do |t|
-              children = testable_fields(t, called_fields: called_fields.dup, depth: depth + 1, ancestors: [f, *ancestors])
-              Field.new(name: "... on #{t}", children: children)
+              t_def = type_definition(t.name)
+              children = testable_fields(t_def, called_fields: called_fields.dup, depth: depth + 1, ancestors: [f, *ancestors])
+              Field.new(name: "... on #{t.name}", children: children)
             end
             Field.new(name: f.name, children: possible_types + [Field::TYPE_NAME], arguments: arguments)
           else

--- a/lib/graphql/autotest/query_generator.rb
+++ b/lib/graphql/autotest/query_generator.rb
@@ -36,7 +36,7 @@ module GraphQL
 
           called_fields << already_called_key
 
-          field_type = unwrap f.type
+          field_type = Util.unwrap f.type
           field_type_def = type_definition(field_type.name)
 
           case field_type_def
@@ -62,12 +62,6 @@ module GraphQL
 
       private def type_definition(name)
         document.definitions.find { |f| f.name == name }
-      end
-
-      private def unwrap(type)
-        return type unless type.respond_to?(:of_type)
-
-        unwrap(type.of_type)
       end
     end
   end

--- a/lib/graphql/autotest/query_generator.rb
+++ b/lib/graphql/autotest/query_generator.rb
@@ -40,7 +40,7 @@ module GraphQL
           field_type_def = type_definition(field_type.name)
 
           case field_type_def
-          when nil, GraphQL::Language::Nodes::EnumTypeDefinition
+          when nil, GraphQL::Language::Nodes::EnumTypeDefinition, GraphQL::Language::Nodes::ScalarTypeDefinition
             Field.new(name: f.name, children: nil, arguments: arguments)
           when GraphQL::Language::Nodes::UnionTypeDefinition
             possible_types = field_type_def.types.map do |t|

--- a/lib/graphql/autotest/runner.rb
+++ b/lib/graphql/autotest/runner.rb
@@ -21,7 +21,8 @@ module GraphQL
         report = Report.new(executions: [])
 
         fields = QueryGenerator.generate(
-          schema: schema,
+          # FIXME
+          document: schema.to_document,
           arguments_fetcher: arguments_fetcher,
           max_depth: max_depth,
           skip_if: skip_if,

--- a/lib/graphql/autotest/runner.rb
+++ b/lib/graphql/autotest/runner.rb
@@ -21,7 +21,6 @@ module GraphQL
         report = Report.new(executions: [])
 
         fields = QueryGenerator.generate(
-          # FIXME
           document: schema.to_document,
           arguments_fetcher: arguments_fetcher,
           max_depth: max_depth,

--- a/lib/graphql/autotest/util.rb
+++ b/lib/graphql/autotest/util.rb
@@ -1,0 +1,17 @@
+module GraphQL
+  module Autotest
+    module Util
+      extend self
+
+      def non_null?(type)
+        type.is_a?(GraphQL::Language::Nodes::NonNullType)
+      end
+
+      def unwrap(type)
+        return type unless type.respond_to?(:of_type)
+
+        unwrap(type.of_type)
+      end
+    end
+  end
+end

--- a/test/graphql/autotest/query_generator_test.rb
+++ b/test/graphql/autotest/query_generator_test.rb
@@ -15,7 +15,7 @@ class QueryGeneratorTest < Minitest::Test
   end
 
   def test_simple_schema
-    fields = GraphQL::Autotest::QueryGenerator.generate(schema: SimpleSchema.to_document)
+    fields = generate(schema: SimpleSchema)
     assert_query [<<~GRAPHQL, '__typename'], fields
       latestNote {
         content
@@ -27,7 +27,7 @@ class QueryGeneratorTest < Minitest::Test
 
   def test_simple_schema_with_skip_if
     skip_if = -> (field, **) { field.name == 'content' }
-    fields = GraphQL::Autotest::QueryGenerator.generate(schema: SimpleSchema.to_document, skip_if: skip_if)
+    fields = generate(schema: SimpleSchema, skip_if: skip_if)
     assert_query [<<~GRAPHQL, '__typename'], fields
       latestNote {
         title
@@ -60,7 +60,7 @@ class QueryGeneratorTest < Minitest::Test
   end
 
   def test_nest_schema
-    fields = GraphQL::Autotest::QueryGenerator.generate(schema: NestSchema.to_document)
+    fields = generate(schema: NestSchema)
     assert_query [<<~GRAPHQL, '__typename'], fields
       latestNote {
         author {
@@ -81,7 +81,7 @@ class QueryGeneratorTest < Minitest::Test
   end
 
   def test_nest_schema_with_max_depth_1
-    fields = GraphQL::Autotest::QueryGenerator.generate(schema: NestSchema.to_document, max_depth: 1)
+    fields = generate(schema: NestSchema, max_depth: 1)
     assert_query [<<~GRAPHQL, '__typename'], fields
       latestNote {
         author {
@@ -96,7 +96,7 @@ class QueryGeneratorTest < Minitest::Test
   end
 
   def test_nest_schema_with_max_depth_2
-    fields = GraphQL::Autotest::QueryGenerator.generate(schema: NestSchema.to_document, max_depth: 2)
+    fields = generate(schema: NestSchema, max_depth: 2)
     assert_query [<<~GRAPHQL, '__typename'], fields
       latestNote {
         author {
@@ -129,7 +129,7 @@ class QueryGeneratorTest < Minitest::Test
   end
 
   def test_circular_schema
-    fields = GraphQL::Autotest::QueryGenerator.generate(schema: CircularSchema.to_document)
+    fields = generate(schema: CircularSchema)
     assert_query [<<~GRAPHQL, '__typename'], fields
       user {
         name
@@ -170,7 +170,7 @@ class QueryGeneratorTest < Minitest::Test
   end
 
   def test_circular_schema2
-    fields = GraphQL::Autotest::QueryGenerator.generate(schema: CircularSchema2.to_document)
+    fields = generate(schema: CircularSchema2)
     assert_query [<<~GRAPHQL, '__typename'], fields
       user {
         latestNote {
@@ -213,7 +213,7 @@ class QueryGeneratorTest < Minitest::Test
   end
 
   def test_arguments_schema1
-    fields = GraphQL::Autotest::QueryGenerator.generate(schema: ArgumentsSchema.to_document)
+    fields = generate(schema: ArgumentsSchema)
     assert_query [<<~GRAPHQL, '__typename'], fields
       usersWithOptionalFirst {
         name
@@ -242,6 +242,10 @@ class QueryGeneratorTest < Minitest::Test
         __typename
       }
     GRAPHQL2
+  end
+
+  private def generate(schema:, **kw)
+    GraphQL::Autotest::QueryGenerator.generate(schema: schema.to_document, **kw)
   end
 
   private def assert_query(expected, got)

--- a/test/graphql/autotest/query_generator_test.rb
+++ b/test/graphql/autotest/query_generator_test.rb
@@ -227,8 +227,8 @@ class QueryGeneratorTest < Minitest::Test
       GraphQL::Autotest::ArgumentsFetcher::DEFAULT,
       -> (field, **) { field.arguments.map(&:name) == ['first'] && { first: 4} }
     )
-    fields = GraphQL::Autotest::QueryGenerator.generate(
-      schema: ArgumentsSchema.to_document,
+    fields = generate(
+      schema: ArgumentsSchema,
       arguments_fetcher: fetcher,
     )
     assert_query [<<~GRAPHQL, <<~GRAPHQL2, '__typename'], fields
@@ -245,7 +245,7 @@ class QueryGeneratorTest < Minitest::Test
   end
 
   private def generate(schema:, **kw)
-    GraphQL::Autotest::QueryGenerator.generate(schema: schema.to_document, **kw)
+    GraphQL::Autotest::QueryGenerator.generate(document: schema.to_document, **kw)
   end
 
   private def assert_query(expected, got)

--- a/test/graphql/autotest/query_generator_test.rb
+++ b/test/graphql/autotest/query_generator_test.rb
@@ -36,6 +36,33 @@ class QueryGeneratorTest < Minitest::Test
     GRAPHQL
   end
 
+  class ScalarTypeSchema < GraphQL::Schema
+    class DateTime < GraphQL::Schema::Scalar
+    end
+
+    class NoteType < GraphQL::Schema::Object
+      field :title, String, null: false
+      field :updated_at, DateTime, null: false
+    end
+
+    class QueryType < GraphQL::Schema::Object
+      field :latest_note, NoteType, null: true
+    end
+
+    query QueryType
+  end
+
+  def test_scalar_type_schema
+    fields = generate(schema: ScalarTypeSchema)
+    assert_query [<<~GRAPHQL, '__typename'], fields
+      latestNote {
+        title
+        updatedAt
+        __typename
+      }
+    GRAPHQL
+  end
+
   class NestSchema < GraphQL::Schema
     class AvatarType < GraphQL::Schema::Object
       field :data, String, null: false


### PR DESCRIPTION
# What

The QueryGeneraotr will generate queries from `GraphQL::Language::Nodes::Document` instead of `GraphQL::Schema` by this pull request.

# Motivation


First, now this gem supports GraphQL schema that is defined by NOT graphql-ruby. Because it needs only schema definition to generate queries.

And I think this change improves maintainability.
graphql-ruby has many breaking changes, but I guess the schema definition code is more stable than the schema definition because it has less responsibility.

----


I think this pull-request keeps most compatibilities, but it has only a few incompatibilities. For example, the order of fields is changed.