### PR TITLE
add debug output

### DIFF
--- a/lib/graphql/autotest/runner.rb
+++ b/lib/graphql/autotest/runner.rb
@@ -1,20 +1,21 @@
 module GraphQL
   module Autotest
     class Runner
-      attr_reader :schema, :context, :arguments_fetcher, :max_depth, :skip_if
-      private :schema, :context, :arguments_fetcher, :max_depth, :skip_if
+      attr_reader :schema, :context, :arguments_fetcher, :max_depth, :skip_if, :debug
+      private :schema, :context, :arguments_fetcher, :max_depth, :skip_if, :debug
 
       # @param schema [Class<GraphQL::Schema>]
       # @param context [Hash] it passes to GraphQL::Schema.execute
       # @param arguments_fetcher [Proc] A proc receives a field and ancestors keyword argument, and it returns a Hash. The hash is passed to call the field.
       # @param max_depth [Integer] Max query depth. It is recommended to specify to avoid too large query.
       # @param skip_if [Proc] A proc receives a field and ancestors keyword argument, and it returns a boolean. If it returns ture, the field is skipped.
-      def initialize(schema:, context:, arguments_fetcher: ArgumentsFetcher::DEFAULT, max_depth: 10, skip_if: -> (_field, **) { false })
+      def initialize(schema:, context:, arguments_fetcher: ArgumentsFetcher::DEFAULT, max_depth: 10, skip_if: -> (_field, **) { false }, debug:)
         @schema = schema
         @context = context
         @arguments_fetcher = arguments_fetcher
         @max_depth = max_depth
         @skip_if = skip_if
+        @debug = debug
       end
 
       def report(dry_run: false)
@@ -28,7 +29,9 @@ module GraphQL
         )
         fields.each do |f|
           q = f.to_query
-
+          
+          puts "Running Query: #{f.name}" if debug
+          
           result = if dry_run
                      {}
                    else

--- a/lib/graphql/autotest/runner.rb
+++ b/lib/graphql/autotest/runner.rb
@@ -1,21 +1,21 @@
 module GraphQL
   module Autotest
     class Runner
-      attr_reader :schema, :context, :arguments_fetcher, :max_depth, :skip_if, :debug
-      private :schema, :context, :arguments_fetcher, :max_depth, :skip_if, :debug
+      attr_reader :schema, :context, :arguments_fetcher, :max_depth, :skip_if, :logger
+      private :schema, :context, :arguments_fetcher, :max_depth, :skip_if, :logger
 
       # @param schema [Class<GraphQL::Schema>]
       # @param context [Hash] it passes to GraphQL::Schema.execute
       # @param arguments_fetcher [Proc] A proc receives a field and ancestors keyword argument, and it returns a Hash. The hash is passed to call the field.
       # @param max_depth [Integer] Max query depth. It is recommended to specify to avoid too large query.
       # @param skip_if [Proc] A proc receives a field and ancestors keyword argument, and it returns a boolean. If it returns ture, the field is skipped.
-      def initialize(schema:, context:, arguments_fetcher: ArgumentsFetcher::DEFAULT, max_depth: 10, skip_if: -> (_field, **) { false }, debug:)
+      def initialize(schema:, context:, arguments_fetcher: ArgumentsFetcher::DEFAULT, max_depth: 10, skip_if: -> (_field, **) { false }, logger:)
         @schema = schema
         @context = context
         @arguments_fetcher = arguments_fetcher
         @max_depth = max_depth
         @skip_if = skip_if
-        @debug = debug
+        @logger = logger
       end
 
       def report(dry_run: false)
@@ -30,7 +30,9 @@ module GraphQL
         fields.each do |f|
           q = f.to_query
           
-          puts "Running Query: #{f.name}" if debug
+           if logger && logger.respond_to?(:info)
+             logger.info "Running Query: #{f.name}"
+           end
           
           result = if dry_run
                      {}


### PR DESCRIPTION
using `debug: true` to display the current query within a rake task


```ruby 
require 'graphql/autotest'

namespace :autotest do
  desc "GraphQL::Autotest tests"
  task report: :environment do
    runner = GraphQL::Autotest::Runner.new(
    schema: MyApiSchema,
    logger: Logger.new($stdout),
    context: {  }
    )

    runner.report!
  end

end
```
$ rake autotest:report

```
Running Query: retailer
Running Query: retailers
Running Query: user
Running Query: users
Running Query: __typename
```