### PR TITLE
Make logger optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## master (unreleased)
 
+* [#10](https://github.com/bitjourney/graphql-autotest/pull/10): Make `logger` argument of `GraphQL::Autotest::Runner` optional.
+
 ## 0.2.0
 
-* `GraphQL::Autotest::Runner` receives `logger` keyword argument.
+* [#8](https://github.com/bitjourney/graphql-autotest/pull/8): `GraphQL::Autotest::Runner` receives `logger` keyword argument.
 
 ## 0.1.2 (2020-03-18)
 

--- a/lib/graphql/autotest/runner.rb
+++ b/lib/graphql/autotest/runner.rb
@@ -9,7 +9,7 @@ module GraphQL
       # @param arguments_fetcher [Proc] A proc receives a field and ancestors keyword argument, and it returns a Hash. The hash is passed to call the field.
       # @param max_depth [Integer] Max query depth. It is recommended to specify to avoid too large query.
       # @param skip_if [Proc] A proc receives a field and ancestors keyword argument, and it returns a boolean. If it returns ture, the field is skipped.
-      def initialize(schema:, context:, arguments_fetcher: ArgumentsFetcher::DEFAULT, max_depth: 10, skip_if: -> (_field, **) { false }, logger:)
+      def initialize(schema:, context:, arguments_fetcher: ArgumentsFetcher::DEFAULT, max_depth: 10, skip_if: -> (_field, **) { false }, logger: Logger.new(nil))
         @schema = schema
         @context = context
         @arguments_fetcher = arguments_fetcher
@@ -30,9 +30,7 @@ module GraphQL
         fields.each do |f|
           q = f.to_query
           
-           if logger && logger.respond_to?(:info)
-             logger.info "Running Query: #{f.name}"
-           end
+          logger.info "Running Query: #{f.name}"
           
           result = if dry_run
                      {}


### PR DESCRIPTION
`logger` option has been introduced by #8, but it would be better if it is optional for backward compatibility.