### PR TITLE
Add support for field arguments

### DIFF
--- a/lib/graphql/autotest/field.rb
+++ b/lib/graphql/autotest/field.rb
@@ -16,13 +16,17 @@ module GraphQL
       end
 
       private def _to_query
-        return name unless children
-
-        <<~GRAPHQL
-          #{name}#{arguments_to_query} {
-          #{indent(children_to_query, 2)}
-          }
-        GRAPHQL
+        if children
+          <<~GRAPHQL
+            #{name}#{arguments_to_query} {
+            #{indent(children_to_query, 2)}
+            }
+          GRAPHQL
+        elsif arguments && arguments.size > 0
+          "#{name}#{arguments_to_query}"
+        else
+          name
+        end
       end
 
       private def children_to_query


### PR DESCRIPTION
Hi.
I am using this software to implement E2E testing on my project.
I would like to report that I found a behavior that seems to be a bug when I run the generator in following GraphQL Schema.
And I tried to fix it myself, But... I'm a Java engineer, so my code may not be elegant :sweat_smile:


## What
When an argument is defined for a field, it will output to the query.



## Why
The problem is that passing an ArgumentFetcher does not affect the query when arguments are defined for the field.

### Example
```ruby
require 'graphql/autotest'

schema =<<SCHEMA
type Item {
  title(lang: String): String
}
type Query {
  item: Item
}
SCHEMA

document = GraphQL::parse(schema)

fill_lang = proc do |field|
  field.arguments.any? { |arg| arg.name == 'lang' } && { lang: %("ja") }
end

fields = GraphQL::Autotest::QueryGenerator.generate(
  document: document,
  arguments_fetcher: GraphQL::Autotest::ArgumentsFetcher.combine(
    fill_lang,
    GraphQL::Autotest::ArgumentsFetcher::DEFAULT,
  )
)

fields.each do |f|
  puts "#{f.to_query}"
end
```

### Output
```
{
  item {
    title    # <= The "lang" argument was not output even with ArgumentFetcher specified
    __typename
  }
}
{
  __typename
}
```

### My environment
- ruby: 3.1.3p185
- bundler: 2.3.26
- graphql: 2.0.20
- graphql-autotest: 0.2.1
- OS: macOS 12.6 (Apple M1)


---

Thank you for providing great software.

takeyoda