### PR TITLE
Migrating from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,21 @@
+name: Testing
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.2", "3.1", "3.0", "2.7", "2.6", "2.5"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle install
+      - run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - 2.6.6
-  - 2.7.2
-  - 3.0.0
-  - ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#15](https://github.com/bitjourney/graphql-autotest/pull/15): Migrating from Travis CI to GitHub Actions. (by @shimbaco)
 * [#14](https://github.com/bitjourney/graphql-autotest/pull/14): Add support for field arguments. (by @takeyoda)
 
 ## 0.2.1 (2020-04-13)


### PR DESCRIPTION
We are no longer using Travis CI, so we will switch to using GitHub Actions.