### PR TITLE
Add supports for Type extention ("extend type" syntax)

### DIFF
--- a/lib/graphql/autotest/query_generator.rb
+++ b/lib/graphql/autotest/query_generator.rb
@@ -70,8 +70,20 @@ module GraphQL
       end
 
       private def type_definition(name)
-        document.definitions.find { |f| f.name == name }
+        defs = document.definitions.select { |f| f.name == name }
+        return defs.first if defs.size <= 1
+
+        MergedDefinition.new(name, defs.flat_map(&:fields))
       end
     end
+
+    class MergedDefinition
+      attr_reader :name, :fields
+      def initialize(name, fields)
+        @name = name
+        @fields = fields
+      end
+    end
+    private_constant :MergedDefinition
   end
 end

--- a/test/graphql/autotest/query_generator_test.rb
+++ b/test/graphql/autotest/query_generator_test.rb
@@ -353,6 +353,30 @@ class QueryGeneratorTest < Minitest::Test
     GRAPHQL
   end
 
+  def test_extended_type_schema
+    schema = <<~GRAPHQL
+      type Item {
+        title: String!
+      }
+      extend type Item {
+        price: Int!
+      }
+      type Query {
+        item: Item!
+      }
+    GRAPHQL
+    document = GraphQL::parse(schema)
+    fields = GraphQL::Autotest::QueryGenerator.generate(document: document)
+
+    assert_query [<<~GRAPHQL, '__typename'], fields
+      item {
+        price
+        title
+        __typename
+      }
+    GRAPHQL
+  end
+
   private def generate(schema:, **kw)
     GraphQL::Autotest::QueryGenerator.generate(document: schema.to_document, **kw)
   end


### PR DESCRIPTION
### What
Add supports for Type extention ("extend type" syntax)

### Why
In GraphQL, we can extend a type using the "extend type" syntax, like the following example:

```graphql
type Item {
  title: String!
}
extend type Item { # HERE
  price: Int!
}
type Query {
  item: Item
}
```

Type "Item" contains two attributes "title" and "price".
When generating a GraphQL query with graphql-autotest from the above schema,
the "price" attribute is not output.

In GraphQL-Ruby, an "extend type" block is treated as an independent instance of [ObjectTypeExtension](https://graphql-ruby.org/api-doc/2.0.24/GraphQL/Language/Nodes/ObjectTypeExtension.html) class.
It means that multiple definitions with the same name are included in Document#definitions.
On the other hand, [QueryGenerator#type_definition](https://github.com/bitjourney/graphql-autotest/blob/d1d534d2fadd727a0a2197b0087693bff75c762c/lib/graphql/autotest/query_generator.rb#L72-L74) assumes that there is only one definition that matches the name, so the definition inside the "extend type" block is not considered.

- Example
  ```ruby
  require 'graphql'
  
  schema = <<~SCHEMA
    type Item {
      title: String!
    }
    extend type Item {
      price: Int!
    }
    type Query {
      item: Item!
    }
  SCHEMA
  
  doc = GraphQL::parse(schema)
  doc.definitions.map do |d|
    puts "name=#{d.name} (#{d.class})"
  end
  ```

  - Output
  ```
  name=Item (GraphQL::Language::Nodes::ObjectTypeDefinition)
  name=Item (GraphQL::Language::Nodes::ObjectTypeExtension)     # contains same named Node
  name=Query (GraphQL::Language::Nodes::ObjectTypeDefinition)
  ```

### How to fix
Changed QueryGenerator#type_definition to merge all definitions that matched name.

### ⚠️ Note ⚠️ 
This change made graphql-autotest work as I expected, but I'm not sure it's the correct change.
For example, I'm worried about the following case expression:
https://github.com/bitjourney/graphql-autotest/blob/d1d534d2fadd727a0a2197b0087693bff75c762c/lib/graphql/autotest/query_generator.rb#L50-L69


--
takeyoda

