### PR TITLE
No need to add double quotation marks before and after with a string argument value.

### DIFF
--- a/lib/graphql/autotest/field.rb
+++ b/lib/graphql/autotest/field.rb
@@ -40,7 +40,7 @@ module GraphQL
         return if arguments.empty?
 
         inner = arguments.map do |k, v|
-          "#{k}: #{v}"
+          v.is_a?(String) ? "#{k}: \"#{v}\"" : "#{k}: #{v}"
         end.join(', ')
         "(#{inner})"
       end


### PR DESCRIPTION
Please be cautious when merging, as this change is a **breaking change** and does not ensure the preservation of existing behavior. Currently, when passing arguments to GraphQL::Autotest::ArgumentsFetcher and the argument is a string, it needs to be enclosed in double quotation marks. To make this more intuitive, I modified it to a form where double quotation marks are not necessary.

#### before
```rb
    fetcher = GraphQL::Autotest::ArgumentsFetcher.combine(
      GraphQL::Autotest::ArgumentsFetcher::DEFAULT,
      -> (field, **) { field.arguments.map(&:name) == ['stringField'] && { stringField: '"string field"' } } # here!
    )
    fields = generate(
      schema: ArgumentsSchema,
      arguments_fetcher: fetcher,
    )
```

#### after
```rb
    fetcher = GraphQL::Autotest::ArgumentsFetcher.combine(
      GraphQL::Autotest::ArgumentsFetcher::DEFAULT,
      -> (field, **) { field.arguments.map(&:name) == ['stringField'] && { stringField: 'string field' } } # here!
    )
    fields = generate(
      schema: ArgumentsSchema,
      arguments_fetcher: fetcher,
    )
```

While it may feel like the intended behavior, as some tests included the use of double quotation marks, I would appreciate considering alternative approaches such as documenting this behavior elsewhere.

I also considered not making changes when the argument already had double quotation marks at the beginning and end to avoid causing a breaking change. However, determining whether these double quotation marks are part of the argument string or not proved challenging. Therefore, I opted to make the modification to "unnecessary" rather than leaving it as "either is fine."